### PR TITLE
default to non-strict tag parsing

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -21,6 +21,7 @@ var (
 	pupEscapeHTML    bool          = true
 	pupIndentString  string        = " "
 	pupDisplayer     Displayer     = TreeDisplayer{}
+	pupGetTagFunc    GetTagFunc    = LooseGetTag
 )
 
 // Parse the html while handling the charset
@@ -56,6 +57,7 @@ Flags
     -n --number        print number of elements selected
     -l --limit         restrict number of levels printed
     -p --plain         don't escape html
+    -s --strict        ignore non-standard HTML tags
     --pre              preserve preformatted text
     --charset          specify the charset for pup to use
     --version          display version
@@ -91,6 +93,8 @@ func ProcessFlags(cmds []string) (nonFlagCmds []string, err error) {
 			pupEscapeHTML = false
 		case "--pre":
 			pupPreformatted = true
+		case "-s", "--strict":
+			pupGetTagFunc = StrictGetTag
 		case "-f", "--file":
 			filename := cmds[i+1]
 			pupIn, err = os.Open(filename)

--- a/selector.go
+++ b/selector.go
@@ -11,6 +11,16 @@ import (
 	"golang.org/x/net/html"
 )
 
+type GetTagFunc func(node *html.Node) string
+
+func StrictGetTag(node *html.Node) string {
+	return node.DataAtom.String()
+}
+
+func LooseGetTag(node *html.Node) string {
+	return node.Data
+}
+
 type Selector interface {
 	Match(node *html.Node) bool
 }
@@ -86,7 +96,7 @@ func (s CSSSelector) Match(node *html.Node) bool {
 		return false
 	}
 	if s.Tag != "" {
-		if s.Tag != node.DataAtom.String() {
+		if s.Tag != pupGetTagFunc(node) {
 			return false
 		}
 	}


### PR DESCRIPTION
Previously, `pup` would skip non-standard HTML tags, as determined
by Go's own parser. This PR makes `pup` accept all tags by default,
and relegate "strict" mode to an option.