### PR TITLE
relax attribute name check

### DIFF
--- a/display.go
+++ b/display.go
@@ -21,7 +21,8 @@ type Displayer interface {
 }
 
 func ParseDisplayer(cmd string) error {
-	attrRe := regexp.MustCompile(`attr\{([a-zA-Z\-]+)\}`)
+	// Ref: https://www.w3.org/TR/2012/WD-html5-20120329/syntax.html#syntax-attribute-name
+	attrRe := regexp.MustCompile(`attr\{([^\s"'>/=\p{Cc}]+)\}`)
 	if cmd == "text{}" {
 		pupDisplayer = TextDisplayer{}
 	} else if cmd == "json{}" {

--- a/tests/cmds.txt
+++ b/tests/cmds.txt
@@ -32,6 +32,7 @@ td:empty
 .summary
 [class=summary]
 [class="summary"]
+[keep:empty]
 #toc
 #toc li + a
 #toc li + a text{}

--- a/tests/expected_output.txt
+++ b/tests/expected_output.txt
@@ -10,12 +10,12 @@ a92e50c09cd56970625ac3b74efbddb83b2731bb table li
 66950e746590d7f4e9cfe3d1adef42cd0addcf1d table li:last-of-type
 0a37d612cd4c67a42bd147b1edc5a1128456b017 table a[title="The Practice of Programming"]
 0d3918d54f868f13110262ffbb88cbb0b083057d table a[title="The Practice of Programming"] text{}
-199188dc8f1522426a628e41d96264bffb8beb0f json{}
+87f5da2293a986a4699c0fb6c136d5d5205df768 json{}
 95ef88ded9dab22ee3206cca47b9c3a376274bda text{}
 e4f7358fbb7bb1748a296fa2a7e815fa7de0a08b .after-portlet
 da39a3ee5e6b4b0d3255bfef95601890afd80709 .after
 8c3d99638ba48ab6487b76929ab796ca1b40adc7 .dtstart.updated
-5b3020ba03fb43f7cdbcb3924546532b6ec9bd71 :empty
+9ef12e8e33809b2bddeccf158dc6f6abb48be39a :empty
 3406ca0f548d66a7351af5411ce945cf67a2f849 td:empty
 30fff0af0b1209f216d6e9124e7396c0adfa0758 .navbox-list li:nth-child(1)
 a38e26949f047faab5ea7ba2acabff899349ce03 .navbox-list li:nth-child(2)
@@ -27,11 +27,12 @@ d314e83b059bb876b0e5ee76aa92d54987961f9a .navbox-list li:nth-last-child(1)
 0b20c98650efa5df39d380fea8d5b43f3a08cb66 .navbox-list li:nth-child(3n+1)
 52e726f0993d2660f0fb3ea85156f6fbcc1cfeee .navbox-list li:nth-last-child(n+1)
 972973fe1e8f63e4481c8641d6169c638a528a6e .navbox-list li:nth-last-child(3n+1)
-6c45ee6bca361b8a9baee50a15f575fc6ac73adc :only-child
+56e8ed51e02c09a487e5356b632db0c8822284e8 :only-child
 44c99f6ad37b65dc0893cdcb1c60235d827ee73e .navbox-list li:only-child
 641037814e358487d1938fc080e08f72a3846ef8 .summary
 641037814e358487d1938fc080e08f72a3846ef8 [class=summary]
 641037814e358487d1938fc080e08f72a3846ef8 [class="summary"]
+8ebb34c81dd0095b7cbf5580ffb5415567e2c137 [keep:empty]
 613bf65ac4042b6ee0a7a47f08732fdbe1b5b06b #toc
 da39a3ee5e6b4b0d3255bfef95601890afd80709 #toc li + a
 da39a3ee5e6b4b0d3255bfef95601890afd80709 #toc li + a text{}

--- a/tests/index.html
+++ b/tests/index.html
@@ -115,7 +115,7 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 </table>
 <p><b>Go</b>, also commonly referred to as <b>golang</b>, is a programming language initially developed at <a href="/wiki/Google" title="Google">Google</a><sup id="cite_ref-6" class="reference"><a href="#cite_note-6"><span>[</span>6<span>]</span></a></sup> in 2007 by <a href="/wiki/Robert_Griesemer" title="Robert Griesemer">Robert Griesemer</a>, <a href="/wiki/Rob_Pike" title="Rob Pike">Rob Pike</a>, and <a href="/wiki/Ken_Thompson" title="Ken Thompson">Ken Thompson</a>.<sup id="cite_ref-langfaq_2-1" class="reference"><a href="#cite_note-langfaq-2"><span>[</span>2<span>]</span></a></sup> It is a statically-<a href="/wiki/Type_system" title="Type system">typed</a> language with syntax loosely derived from that of C, adding <a href="/wiki/Garbage_collection_(computer_science)" title="Garbage collection (computer science)">garbage collection</a>, <a href="/wiki/Type_safety" title="Type safety">type safety</a>, some <a href="/wiki/Dynamic_typing" title="Dynamic typing" class="mw-redirect">dynamic-typing</a> capabilities, additional built-in types such as <a href="/wiki/Variable-length_array" title="Variable-length array">variable-length arrays</a> and key-value maps, and a large standard library.</p>
 <p>The language was announced in November 2009 and is now used in some of Google's production systems.<sup id="cite_ref-faq_7-0" class="reference"><a href="#cite_note-faq-7"><span>[</span>7<span>]</span></a></sup> Go's "gc" compiler targets the <a href="/wiki/Linux" title="Linux">Linux</a>, <a href="/wiki/Mac_OS_X" title="Mac OS X" class="mw-redirect">Mac OS X</a>, <a href="/wiki/FreeBSD" title="FreeBSD">FreeBSD</a>, <a href="/wiki/NetBSD" title="NetBSD">NetBSD</a>, <a href="/wiki/OpenBSD" title="OpenBSD">OpenBSD</a>, <a href="/wiki/Plan_9_from_Bell_Labs" title="Plan 9 from Bell Labs">Plan 9</a>, and <a href="/wiki/Microsoft_Windows" title="Microsoft Windows">Microsoft Windows</a> operating systems and the <a href="/wiki/I386" title="I386" class="mw-redirect">i386</a>, <a href="/wiki/Amd64" title="Amd64" class="mw-redirect">amd64</a>, and <a href="/wiki/ARM_architecture" title="ARM architecture">ARM</a> processor architectures.<sup id="cite_ref-8" class="reference"><a href="#cite_note-8"><span>[</span>8<span>]</span></a></sup> A second compiler, gccgo, is a <a href="/wiki/GNU_Compiler_Collection" title="GNU Compiler Collection">GCC</a> frontend.<sup id="cite_ref-9" class="reference"><a href="#cite_note-9"><span>[</span>9<span>]</span></a></sup><sup id="cite_ref-10" class="reference"><a href="#cite_note-10"><span>[</span>10<span>]</span></a></sup></p>
-<p></p>
+<p keep:empty></p>
 <div id="toc" class="toc">
 <div id="toctitle">
 <h2>Contents</h2>
@@ -157,7 +157,7 @@ mw.loader.load(["mediawiki.page.startup","mediawiki.legacy.wikibits","mediawiki.
 <li class="toclevel-1 tocsection-25"><a href="#External_links"><span class="tocnumber">15</span> <span class="toctext">External links</span></a></li>
 </ul>
 </div>
-<p></p>
+<p keep:empty></p>
 <h2><span class="mw-headline" id="History">History</span><span class="mw-editsection"><span class="mw-editsection-bracket">[</span><a href="/w/index.php?title=Go_(programming_language)&amp;action=edit&amp;section=1" title="Edit section: History">edit</a><span class="mw-editsection-bracket">]</span></span></h2>
 <p>Ken Thompson states that, initially, Go was purely an experimental project. Referring to himself along with the other original authors of Go, he states:<sup id="cite_ref-11" class="reference"><a href="#cite_note-11"><span>[</span>11<span>]</span></a></sup></p>
 <blockquote class="templatequote">
@@ -1324,7 +1324,7 @@ Lua memory usage: 3.99 MB/50 MB
 												<h3 id="p-variants-label"><span>Variants</span><a href="#"></a></h3>
 
 						<div class="menu">
-							<ul>
+							<ul keep:empty>
 															</ul>
 						</div>
 					</div>
@@ -1342,7 +1342,7 @@ Lua memory usage: 3.99 MB/50 MB
 						<h3 id="p-cactions-label"><span>More</span><a href="#"></a></h3>
 
 						<div class="menu">
-							<ul>
+							<ul keep:empty>
 															</ul>
 						</div>
 					</div>


### PR DESCRIPTION
Otherwise valid attribute names like `a:b1` can't be used.

Cherry-picked from https://github.com/ericchiang/pup/pull/175.