### PR TITLE
Do not use strings.TrimSpace for case html.TextNode

### DIFF
--- a/display.go
+++ b/display.go
@@ -279,7 +279,7 @@ func jsonify(node *html.Node) map[string]interface{} {
 		case html.ElementNode:
 			children = append(children, jsonify(child))
 		case html.TextNode:
-			text := strings.TrimSpace(child.Data)
+			text := child.Data
 			if text != "" {
 				if pupEscapeHTML {
 					// don't escape javascript


### PR DESCRIPTION
The current behavior causes pup to produce wrong values for text keys in json output.
No leading/trailing whitespace is for example not okay if you want to get hashes for Content-Security-Policy HTTP headers.

I am really not sure if this behaviour could mess up some other workflows, but for me it is very much expected. If whitespace just gets trimmed, the extracted content gets useless in some cases. People could trim the whitespace themselves if that's what they want. One could also add a new flag that would allow trimming/not trimming whitespace or implement this for other elements.

I have also created the same pr upstream: https://github.com/ericchiang/pup/pull/211

