### PR TITLE
Do not trim space from string when parsing text node in json{} function

### DIFF
--- a/display.go
+++ b/display.go
@@ -280,7 +280,7 @@ func jsonify(node *html.Node) map[string]interface{} {
 		case html.ElementNode:
 			children = append(children, jsonify(child))
 		case html.TextNode:
-			text := strings.TrimSpace(child.Data)
+			text := child.Data
 			if text != "" {
 				if pupEscapeHTML {
 					// don't escape javascript


### PR DESCRIPTION
The current behavior causes pup to produce incorrect values for text in json output by trimming leading and trailing whitespace. That is for example not okay if you want to get hashes for Content-Security-Policy HTTP headers.

I am not sure if this behavior could mess up some other workflows, but for me this behavior very much expected. If whitespace just gets trimmed, the extracted content gets useless in some cases. People could trim the whitespace themselves if that's what they want. One could also add a new flag that would allow trimming/not trimming whitespace or implement this for other elements.

I have previously created the same pr upstream: https://github.com/ericchiang/pup/pull/211

Sorry for recreating this pr. It would've otherwise been hard for me to use this fork as upstream for my repo. Previous pr: https://github.com/gromgit/pup/pull/24